### PR TITLE
Add type to request created event build

### DIFF
--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/GenerationResource.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/GenerationResource.java
@@ -86,6 +86,7 @@ public class GenerationResource {
                 .setEventId(UUID.randomUUID().toString())
                 .setSource("sbomer-rest-api") // Identifies this adapter as the source
                 .setEventVersion("1.0") // As per the schema default
+                .setType("RequestsCreated")
                 .setTimestamp(Instant.now()) // Current time in UTC millis
                 .build();
 


### PR DESCRIPTION
Quick fix to add a forgotten type field to the request.created event built during the REST API call