### PR TITLE
Remove dummy enhancer for container image recipe

### DIFF
--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/MockRecipeBuilder.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/MockRecipeBuilder.java
@@ -34,7 +34,7 @@ public class MockRecipeBuilder implements RecipeBuilder {
                     .setName("syft-generator")
                     .setVersion("1.5.0")
                     .build();
-            enhancers.add(EnhancerSpec.newBuilder().setName("sorting-enhancer").setVersion("1.0.0").build());
+            // enhancers.add(EnhancerSpec.newBuilder().setName("sorting-enhancer").setVersion("1.0.0").build());
         } else {
             // Default or throw an error for unsupported types
             throw new IllegalArgumentException("Unsupported target type: " + type);


### PR DESCRIPTION
Remove dummy enhancer for container image recipe in order to do generations from start to finish