### PR TITLE
Fix the structure and functionality of the handler provided options

### DIFF
--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/SbomResource.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/SbomResource.java
@@ -177,13 +177,13 @@ public class SbomResource {
     @APIResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     public Response retryGeneration(
             @PathParam("id") @NotBlank(message = "Generation ID cannot be blank") String generationId) {
-        
+
         log.debug("Retry requested for generation: {}", generationId);
-        
+
         sbomAdministration.retryGeneration(generationId);
-        
+
         log.info("Successfully scheduled retry for generation: {}", generationId);
-        
+
         return Response.accepted()
                 .entity(new RetryResponse("Retry scheduled", generationId))
                 .build();
@@ -240,13 +240,13 @@ public class SbomResource {
     @APIResponse(responseCode = "500", description = "Internal server error", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ErrorResponse.class)))
     public Response retryEnhancement(
             @PathParam("id") @NotBlank(message = "Enhancement ID cannot be blank") String enhancementId) {
-        
+
         log.debug("Retry requested for enhancement: {}", enhancementId);
-        
+
         sbomAdministration.retryEnhancement(enhancementId);
-        
+
         log.info("Successfully scheduled retry for enhancement: {}", enhancementId);
-        
+
         return Response.accepted()
                 .entity(new RetryResponse("Retry scheduled", enhancementId))
                 .build();
@@ -344,7 +344,7 @@ public class SbomResource {
         // We return the batch RequestId so the user can track it.
         String requestId = requestsCreatedEvent.getData().getRequestId();
         log.info("Successfully triggered generation with request ID: {}", requestId);
-        
+
         return Response.accepted(new TriggerResponse(requestId)).build();
     }
 
@@ -412,7 +412,7 @@ public class SbomResource {
         if (dto.version() == null) {
             throw new ValidationException("Publisher version cannot be null");
         }
-        
+
         return PublisherSpec.newBuilder()
                 .setName(dto.name())
                 .setVersion(dto.version())
@@ -434,7 +434,7 @@ public class SbomResource {
         if (dto.target().identifier() == null) {
             throw new ValidationException("Target identifier cannot be null");
         }
-        
+
         Target target = Target.newBuilder()
                 .setType(dto.target().type())
                 .setIdentifier(dto.target().identifier())
@@ -444,6 +444,7 @@ public class SbomResource {
                 // A new, unique ID for this specific generation task
                 .setGenerationId(TsidUtility.createUniqueGenerationId())
                 .setTarget(target)
+                .setHandlerProvidedOptions(dto.handlerProvidedOptions())
                 .build();
     }
 }

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/dto/GenerationRequestDTO.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/dto/GenerationRequestDTO.java
@@ -1,5 +1,7 @@
 package org.jboss.sbomer.sbom.service.adapter.in.rest.dto;
 
+import java.util.Map;
+
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import jakarta.validation.Valid;
@@ -13,5 +15,7 @@ public record GenerationRequestDTO(
         @NotNull(message = "A target must be specified for each generation request")
         @Valid
         @Schema(description = "The artifact target configuration.", required = true)
-        TargetDTO target
+        TargetDTO target,
+        @Schema(description = "Optional map of key-value configuration options provided by the handler to pass specific flags or overrides.")
+        Map<String, String> handlerProvidedOptions
 ) {}

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/PanacheStatusRepository.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/PanacheStatusRepository.java
@@ -241,6 +241,16 @@ public class PanacheStatusRepository implements StatusRepository {
                 entity.setGeneratorOptions(null);
             }
 
+            if (record.getHandlerProvidedOptions() != null) {
+                if (entity.getHandlerProvidedOptions() == null) {
+                    entity.setHandlerProvidedOptions(new HashMap<>());
+                }
+                entity.getHandlerProvidedOptions().clear();
+                entity.getHandlerProvidedOptions().putAll(record.getHandlerProvidedOptions());
+            } else {
+                entity.setHandlerProvidedOptions(null);
+            }
+
             if (record.getGenerationSbomUrls() != null) {
                 entity.getGenerationSbomUrls().clear();
                 entity.getGenerationSbomUrls().addAll(record.getGenerationSbomUrls());

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/domain/entity/GenerationEntity.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/domain/entity/GenerationEntity.java
@@ -50,6 +50,12 @@ public class GenerationEntity extends PanacheEntityBase {
     @Column(name = "opt_value")
     private Map<String, String> generatorOptions = new HashMap<>();
 
+    @ElementCollection
+    @CollectionTable(name = "generation_handler_options", joinColumns = @JoinColumn(name = "generation_db_id"))
+    @MapKeyColumn(name = "opt_key")
+    @Column(name = "opt_value")
+    private Map<String, String> handlerProvidedOptions = new HashMap<>();
+
     private Instant created;
 
     private Instant updated;

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/domain/dto/GenerationRecord.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/domain/dto/GenerationRecord.java
@@ -25,6 +25,10 @@ public class GenerationRecord {
      * Mapped from the configuration recipe.
      */
     private Map<String, String> generatorOptions;
+    /**
+     * Options provided by the handler that originally created the request.
+     */
+    private Map<String, String> handlerProvidedOptions;
     private Instant created;
     private Instant updated;
     private Instant finished;

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomMapper.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomMapper.java
@@ -73,6 +73,7 @@ public class SbomMapper {
         return GenerationRequestSpec.newBuilder()
                 .setGenerationId(record.getId())
                 .setTarget(target)
+                .setHandlerProvidedOptions(record.getHandlerProvidedOptions())
                 .build();
     }
 
@@ -86,8 +87,8 @@ public class SbomMapper {
         generationRecord.setId(requestSpec.getGenerationId());
         generationRecord.setGeneratorName(recipe.getGenerator().getName());
         generationRecord.setGeneratorVersion(recipe.getGenerator().getVersion());
-        Map<String, String> mergedGeneratorOptions = mergeOptions(recipe.getGenerator().getOptions(), requestSpec.getHandlerProvidedOptions());
-        generationRecord.setGeneratorOptions(mergedGeneratorOptions);
+        generationRecord.setGeneratorOptions(recipe.getGenerator().getOptions());
+        generationRecord.setHandlerProvidedOptions(requestSpec.getHandlerProvidedOptions());
         generationRecord.setCreated(Instant.now()); // Timestamp created here
         generationRecord.setUpdated(Instant.now());
         generationRecord.setStatus(GenerationStatus.PENDING);
@@ -106,8 +107,7 @@ public class SbomMapper {
                 enhancementRecord.setId(TsidUtility.createUniqueEnhancementId());
                 enhancementRecord.setEnhancerName(enhancerSpecs.get(i).getName());
                 enhancementRecord.setEnhancerVersion(enhancerSpecs.get(i).getVersion());
-                Map<String, String> mergedEnhancerOptions = mergeOptions(enhancerSpecs.get(i).getOptions(), requestSpec.getHandlerProvidedOptions());
-                enhancementRecord.setEnhancerOptions(mergedEnhancerOptions);
+                enhancementRecord.setEnhancerOptions(enhancerSpecs.get(i).getOptions());
                 enhancementRecord.setIndex(i); // Preserve order
                 enhancementRecord.setCreated(Instant.now());
                 enhancementRecord.setUpdated(Instant.now());
@@ -198,6 +198,7 @@ public class SbomMapper {
                         .setType(parentGeneration.getTargetType())
                         .setIdentifier(parentGeneration.getTargetIdentifier())
                         .build())
+                .setHandlerProvidedOptions(parentGeneration.getHandlerProvidedOptions())
                 .build();
 
 
@@ -241,6 +242,7 @@ public class SbomMapper {
             GenerationRequestSpec generationRequestSpec = GenerationRequestSpec.newBuilder()
                     .setGenerationId(generationRecord.getId())
                     .setTarget(target)
+                    .setHandlerProvidedOptions(generationRecord.getHandlerProvidedOptions())
                     .build();
             CompletedGeneration completedGeneration = CompletedGeneration.newBuilder()
                     .setGenerationRequest(generationRequestSpec)
@@ -281,24 +283,6 @@ public class SbomMapper {
                 .max(Comparator.comparingInt(EnhancementRecord::getIndex))
                 .map(EnhancementRecord::getEnhancedSbomUrls)
                 .orElse(record.getGenerationSbomUrls());
-    }
-
-    /**
-     * Helper to merge existing options with handler-provided options using a prefix.
-     */
-    private Map<String, String> mergeOptions(Map<String, String> existingOptions, Map<String, String> handlerOptions) {
-        // Start with a copy of existing options (handling null safely)
-        Map<String, String> merged = (existingOptions != null) ? new HashMap<>(existingOptions) : new HashMap<>();
-
-        // Append handler options if present
-        if (handlerOptions != null) {
-            handlerOptions.forEach((key, value) -> {
-                // we put a handler-* prefix for the key to specify it comes from the handler and not the generator or enhancer
-                merged.put("handler-" + key, value);
-            });
-        }
-
-        return merged;
     }
 
 }

--- a/src/main/resources/db/migration/V1.2.0__Add_generation_handler_options.sql
+++ b/src/main/resources/db/migration/V1.2.0__Add_generation_handler_options.sql
@@ -1,0 +1,12 @@
+-- GENERATION HANDLER OPTIONS
+create table generation_handler_options (
+                                            generation_db_id bigint not null,
+                                            opt_key varchar(255) not null,
+                                            opt_value varchar(255),
+                                            primary key (generation_db_id, opt_key)
+);
+
+-- FOREIGN KEYS
+alter table if exists generation_handler_options
+    add constraint FK_gen_hndlr_opt_gen
+    foreign key (generation_db_id) references generations;


### PR DESCRIPTION
I've noticed that the handler provided options were being recorded in our database in a bit of a hacky way (my bad), so I created a separate map for it in the generation entity and dtos, and ensured that it gets set during the API call and also is sent out to the generator and enhancer created events