### PR TITLE
fix: configure connection pool to prevent stale connection failures

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,14 @@ quarkus.datasource.password=${DB_PASSWORD:password}
 quarkus.datasource.metrics.enabled=true
 quarkus.datasource.jdbc.telemetry=true
 
+# Connection pool: keep connections warm and validated
+quarkus.datasource.jdbc.min-size=2
+quarkus.datasource.jdbc.max-size=20
+quarkus.datasource.jdbc.background-validation-interval=30s
+quarkus.datasource.jdbc.validation-query-sql=SELECT 1
+quarkus.datasource.jdbc.acquisition-timeout=10
+quarkus.datasource.jdbc.leak-detection-interval=10m
+
 # Leaving it unset in %dev triggers Dev Services (automatic container).
 %prod.quarkus.datasource.jdbc.url=${DB_URL:jdbc:postgresql://localhost:5432/sbomer}
 


### PR DESCRIPTION
sbom-service was experiencing intermittent database connection validation failures on IBM Cloud:
- Logs showed `validation check failed for the default DataSource`
- Caused 500 errors on API endpoints (e.g. `GET /api/v1/generations`)
- Created `STATUS_CODE_ERROR` traces that exhausted error budget
- `ErrorBudgetExhausted` alert firing due to 0.26% error rate

Cause was default connection pool (`min-size=0`) creating connections on-demand. During idle periods, Postgres closed these connections. When next request arrived pool tried to use a stale connection, resulting in validation failure.

Solution to prevent in future:
- `min-size=2`: Keep 2 connections warm (prevents cold-start validation failures)
- `background-validation-interval=30s`: Proactively test idle connections before requests use them
- `validation-query-sql=SELECT 1`: Lightweight health check
- `acquisition-timeout=10s`: Tolerate transient DB slowness (up from 5s)
- `leak-detection-interval=10m`: Detect unclosed connections