### PR TITLE
Implement Final SBOM URLs Field for Generation Record and Entity

### DIFF
--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/PanacheStatusRepository.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/PanacheStatusRepository.java
@@ -1,13 +1,6 @@
 package org.jboss.sbomer.sbom.service.adapter.out.persistence;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -258,6 +251,16 @@ public class PanacheStatusRepository implements StatusRepository {
                 entity.setGenerationSbomUrls(null);
             }
 
+            if (record.getFinalSbomUrls() != null) {
+                if (entity.getFinalSbomUrls() == null) {
+                    entity.setFinalSbomUrls(new HashSet<>());
+                }
+                entity.getFinalSbomUrls().clear();
+                entity.getFinalSbomUrls().addAll(record.getFinalSbomUrls());
+            } else {
+                entity.setFinalSbomUrls(null);
+            }
+
             mergeEnhancements(entity, record.getEnhancements());
         });
     }
@@ -331,18 +334,11 @@ public class PanacheStatusRepository implements StatusRepository {
 
     @Override
     public List<String> getFinalSbomUrlsForCompletedGeneration(String generationId) {
-        return List.copyOf(generationRepository.find("generationId", generationId).firstResultOptional()
-            .map(generationEntity -> {
-                List<EnhancementEntity> children = enhancementRepository.list("generation.generationId", generationId);
-                return !children.isEmpty() ? children.stream()
-                    .filter(e -> e.getStatus() == EnhancementStatus.COMPLETED)
-                    .max(Comparator.comparingInt(EnhancementEntity::getIndex))
-                    .map(EnhancementEntity::getEnhancedSbomUrls)
-                    .orElse(generationEntity.getGenerationSbomUrls())
-                    : generationEntity.getGenerationSbomUrls();
-
-            })
-            .orElseGet(Set::of));
+        return generationRepository.find("generationId", generationId)
+            .firstResultOptional()
+            .map(GenerationEntity::getFinalSbomUrls)
+            .map(List::copyOf) // Convert Set to List as required by the return type
+            .orElseGet(List::of);
     }
 
     @Override

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/PanacheStatusRepository.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/PanacheStatusRepository.java
@@ -1,8 +1,15 @@
 package org.jboss.sbomer.sbom.service.adapter.out.persistence;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.Collection;
+import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ArrayList;
 
 import org.jboss.sbomer.sbom.service.adapter.in.rest.model.Page;
 import org.jboss.sbomer.sbom.service.adapter.out.persistence.domain.entity.EnhancementEntity;

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/domain/entity/GenerationEntity.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/persistence/domain/entity/GenerationEntity.java
@@ -82,6 +82,11 @@ public class GenerationEntity extends PanacheEntityBase {
     @Column(name = "url")
     private Set<String> generationSbomUrls = new HashSet<>();
 
+    @ElementCollection
+    @CollectionTable(name = "final_sbom_urls", joinColumns = @JoinColumn(name = "generation_db_id"))
+    @Column(name = "url")
+    private Set<String> finalSbomUrls = new HashSet<>();
+
     @OneToMany(mappedBy = "generation", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<EnhancementEntity> enhancements = new HashSet<>();
 

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/domain/dto/GenerationRecord.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/domain/dto/GenerationRecord.java
@@ -38,7 +38,10 @@ public class GenerationRecord {
     private String requestId;
     private String targetType;
     private String targetIdentifier;
+    // SBOMs resulting from the base generation
     private Collection<String> generationSbomUrls;
+    // SBOMs resulting from the full generator->enhancer process
+    private Collection<String> finalSbomUrls;
     private Collection<EnhancementRecord> enhancements;
     private ChildEnhancementsStatus childEnhancementsStatus;
     private GenerationResult latestResult;

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomMapper.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomMapper.java
@@ -225,29 +225,35 @@ public class SbomMapper {
 
         // First build the context
         ContextSpec context = ContextSpec.newBuilder()
-                .setEventId(UUID.randomUUID().toString())
-                .setType("RequestsFinished")
-                .setSource(ApplicationConstants.COMPONENT_NAME)
-                .setCorrelationId(requestRecord.getId())
-                .setEventVersion("1.0")
-                .setTimestamp(Instant.now())
-                .build();
+            .setEventId(UUID.randomUUID().toString())
+            .setType("RequestsFinished")
+            .setSource(ApplicationConstants.COMPONENT_NAME)
+            .setCorrelationId(requestRecord.getId())
+            .setEventVersion("1.0")
+            .setTimestamp(Instant.now())
+            .build();
 
         List<CompletedGeneration>  completedGenerations = new ArrayList<>();
         for (GenerationRecord generationRecord : requestRecord.getGenerationRecords()) {
             Target target = Target.newBuilder()
-                    .setType(generationRecord.getTargetType())
-                    .setIdentifier(generationRecord.getTargetIdentifier())
-                    .build();
+                .setType(generationRecord.getTargetType())
+                .setIdentifier(generationRecord.getTargetIdentifier())
+                .build();
             GenerationRequestSpec generationRequestSpec = GenerationRequestSpec.newBuilder()
-                    .setGenerationId(generationRecord.getId())
-                    .setTarget(target)
-                    .setHandlerProvidedOptions(generationRecord.getHandlerProvidedOptions())
-                    .build();
+                .setGenerationId(generationRecord.getId())
+                .setTarget(target)
+                .setHandlerProvidedOptions(generationRecord.getHandlerProvidedOptions())
+                .build();
+
+            // Directly read finalSbomUrls from the record
+            Collection<String> finalUrls = generationRecord.getFinalSbomUrls() != null
+                ? generationRecord.getFinalSbomUrls()
+                : Collections.emptySet();
+
             CompletedGeneration completedGeneration = CompletedGeneration.newBuilder()
-                    .setGenerationRequest(generationRequestSpec)
-                    .setFinalSbomUrls(List.copyOf(determineFinalUrls(generationRecord))) // TODO: Convert to Collection?
-                    .build();
+                .setGenerationRequest(generationRequestSpec)
+                .setFinalSbomUrls(List.copyOf(finalUrls))
+                .build();
 
             completedGenerations.add(completedGeneration);
         }
@@ -255,34 +261,20 @@ public class SbomMapper {
         List<PublisherSpec> publisherSpecs = new ArrayList<>();
         if (requestRecord.getPublisherRecords() != null) {
             publisherSpecs = requestRecord.getPublisherRecords().stream()
-                    .map(this::toPublisherSpec)
-                    .toList();
+                .map(this::toPublisherSpec)
+                .toList();
         }
 
         RequestsFinishedData requestsFinishedData = RequestsFinishedData.newBuilder()
-                .setRequestId(requestRecord.getId())
-                .setCompletedGenerations(completedGenerations)
-                .setPublishers(publisherSpecs) // TODO
-                .build();
+            .setRequestId(requestRecord.getId())
+            .setCompletedGenerations(completedGenerations)
+            .setPublishers(publisherSpecs) // TODO
+            .build();
 
         return RequestsFinished.newBuilder()
-                .setContext(context)
-                .setData(requestsFinishedData)
-                .build();
-    }
-
-    private Collection<String> determineFinalUrls(GenerationRecord record) {
-        // If no enhancements, or list is null, return base generation URLs
-        if (record.getEnhancements() == null || record.getEnhancements().isEmpty()) {
-            return record.getGenerationSbomUrls();
-        }
-
-        // Find the enhancement with the highest index that has URLs
-        // Since this is only called when requests are finished, we assume the chain completed successfully
-        return record.getEnhancements().stream()
-                .max(Comparator.comparingInt(EnhancementRecord::getIndex))
-                .map(EnhancementRecord::getEnhancedSbomUrls)
-                .orElse(record.getGenerationSbomUrls());
+            .setContext(context)
+            .setData(requestsFinishedData)
+            .build();
     }
 
 }

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomService.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomService.java
@@ -235,10 +235,12 @@ public class SbomService implements GenerationProcessor, GenerationStatusProcess
             if (generationRecord.getEnhancements() == null || generationRecord.getEnhancements().isEmpty()) {
                 finalUrls = generationRecord.getGenerationSbomUrls();
             } else {
+                // We know enhancements exist. If the max index returns null URLs,
+                // it means the final step failed to produce output. Return an empty set.
                 finalUrls = generationRecord.getEnhancements().stream()
                     .max(Comparator.comparingInt(EnhancementRecord::getIndex))
                     .map(EnhancementRecord::getEnhancedSbomUrls)
-                    .orElse(generationRecord.getGenerationSbomUrls());
+                    .orElse(Collections.emptySet());
             }
 
             generationRecord.setFinalSbomUrls(finalUrls);

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomService.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/service/SbomService.java
@@ -228,6 +228,22 @@ public class SbomService implements GenerationProcessor, GenerationStatusProcess
     private void triggerNextStepForGeneration(String generationId, String requestId) {
 
         if (statusRepository.isGenerationAndEnhancementsFinished(generationId)) {
+            // --- Calculate and persist the finalSbomUrls ---
+            GenerationRecord generationRecord = statusRepository.findGenerationById(generationId);
+
+            Collection<String> finalUrls;
+            if (generationRecord.getEnhancements() == null || generationRecord.getEnhancements().isEmpty()) {
+                finalUrls = generationRecord.getGenerationSbomUrls();
+            } else {
+                finalUrls = generationRecord.getEnhancements().stream()
+                    .max(Comparator.comparingInt(EnhancementRecord::getIndex))
+                    .map(EnhancementRecord::getEnhancedSbomUrls)
+                    .orElse(generationRecord.getGenerationSbomUrls());
+            }
+
+            generationRecord.setFinalSbomUrls(finalUrls);
+            statusRepository.updateGeneration(generationRecord);
+
             if (statusRepository.isAllGenerationRequestsFinished(requestId)) {
                 // ALL Generations and Enhancements finished
                 RequestRecord requestRecord = statusRepository.findRequestById(requestId);

--- a/src/main/resources/db/migration/V1.3.0__Add_final_sbom_urls.sql
+++ b/src/main/resources/db/migration/V1.3.0__Add_final_sbom_urls.sql
@@ -1,0 +1,10 @@
+-- FINAL SBOM URLS
+create table final_sbom_urls (
+                                 generation_db_id bigint not null,
+                                 url varchar(255)
+);
+
+-- FOREIGN KEY
+alter table if exists final_sbom_urls
+    add constraint FK_final_urls_gen
+    foreign key (generation_db_id) references generations;

--- a/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/service/MapperTest.java
+++ b/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/service/MapperTest.java
@@ -72,6 +72,8 @@ public class MapperTest {
         generationRecord.setTargetType("image");
         generationRecord.setGenerationSbomUrls(List.of("https://url1", "https://url2"));
 
+        generationRecord.setFinalSbomUrls(List.of("https://final1"));
+
         EnhancementRecord enhancementRecord = new EnhancementRecord();
         String enhancementId = UUID.randomUUID().toString();
         enhancementRecord.setId(enhancementId);
@@ -86,6 +88,7 @@ public class MapperTest {
         assertThat(generationEntity.getEnhancements()).hasSize(1);
         assertThat(generationEntity.getEnhancements()).element(0).extracting("enhancementId").isEqualTo(enhancementId);
         assertThat(generationEntity.getGenerationSbomUrls()).containsExactly("https://url1", "https://url2");
+        assertThat(generationEntity.getFinalSbomUrls()).containsExactly("https://final1");
 
         GenerationRecord generationMapperDto = generationMapper.toDto(generationEntity);
         assertThat(generationMapperDto.getId()).isEqualTo(generationId);
@@ -94,6 +97,7 @@ public class MapperTest {
         // DTO uses "id"
         assertThat(generationMapperDto.getEnhancements()).element(0).extracting("id").isEqualTo(enhancementId);
         assertThat(generationMapperDto.getGenerationSbomUrls()).containsExactly("https://url1", "https://url2");
+        assertThat(generationMapperDto.getFinalSbomUrls()).containsExactly("https://final1");
     }
 
     @Test

--- a/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/service/PanacheStatusRepositoryTest.java
+++ b/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/service/PanacheStatusRepositoryTest.java
@@ -79,6 +79,7 @@ public class PanacheStatusRepositoryTest {
         generationRecord.setGeneratorName("generatorName2");
         generationRecord.setStatus(GenerationStatus.COMPLETED);
         generationRecord.setGenerationSbomUrls(List.of("https://url1", "https://url2"));
+        generationRecord.setFinalSbomUrls(List.of("https://final1", "https://final2"));
 
         statusRepository.updateGeneration(generationRecord);
 
@@ -87,6 +88,7 @@ public class PanacheStatusRepositoryTest {
         assertThat(updated.getGeneratorName()).isEqualTo("generatorName2");
         assertThat(updated.getStatus()).isEqualTo(GenerationStatus.COMPLETED);
         assertThat(updated.getGenerationSbomUrls()).containsExactly("https://url1", "https://url2");
+        assertThat(updated.getFinalSbomUrls()).containsExactly("https://final1", "https://final2");
     }
 
     @Test

--- a/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/service/SbomServiceTest.java
+++ b/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/service/SbomServiceTest.java
@@ -1,8 +1,49 @@
 package org.jboss.sbomer.test.unit.sbom.service.core.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.sbomer.events.common.ContextSpec;
+import org.jboss.sbomer.events.common.GenerationRequestSpec;
+import org.jboss.sbomer.events.common.Target;
+import org.jboss.sbomer.events.enhancer.EnhancementUpdate;
+import org.jboss.sbomer.events.enhancer.EnhancementUpdateData;
+import org.jboss.sbomer.events.generator.GenerationUpdate;
+import org.jboss.sbomer.events.generator.GenerationUpdateData;
+import org.jboss.sbomer.events.orchestration.GenerationCreated;
+import org.jboss.sbomer.events.orchestration.RequestsFinished;
+import org.jboss.sbomer.events.request.RequestData;
+import org.jboss.sbomer.events.request.RequestsCreated;
+import org.jboss.sbomer.sbom.service.core.domain.dto.EnhancementRecord;
+import org.jboss.sbomer.sbom.service.core.domain.dto.EnhancementRunRecord;
+import org.jboss.sbomer.sbom.service.core.domain.dto.GenerationRecord;
+import org.jboss.sbomer.sbom.service.core.domain.dto.GenerationRunRecord;
+import org.jboss.sbomer.sbom.service.core.domain.dto.RequestRecord;
+import org.jboss.sbomer.sbom.service.core.domain.enums.GenerationResult;
+import org.jboss.sbomer.sbom.service.core.domain.enums.RequestStatus;
+import org.jboss.sbomer.sbom.service.core.domain.enums.RunState;
+import org.jboss.sbomer.sbom.service.core.port.api.RunManagement;
+import org.jboss.sbomer.sbom.service.core.port.spi.FailureNotifier;
+import org.jboss.sbomer.sbom.service.core.port.spi.RecipeBuilder;
+import org.jboss.sbomer.sbom.service.core.port.spi.RequestsFinishedNotifier;
+import org.jboss.sbomer.sbom.service.core.port.spi.StatusRepository;
+import org.jboss.sbomer.sbom.service.core.port.spi.enhancement.EnhancementScheduler;
 import org.jboss.sbomer.sbom.service.core.port.spi.generation.GenerationScheduler;
+import org.jboss.sbomer.sbom.service.core.service.SbomMapper;
 import org.jboss.sbomer.sbom.service.core.service.SbomService;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -11,9 +52,218 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class SbomServiceTest {
 
     @InjectMocks
-    private SbomService generationDispatcherService;
+    private SbomService sbomService;
 
     @Mock
     private GenerationScheduler generationScheduler;
 
+    @Mock
+    private EnhancementScheduler enhancementScheduler;
+
+    @Mock
+    private SbomMapper sbomMapper;
+
+    @Mock
+    private StatusRepository statusRepository;
+
+    @Mock
+    private RecipeBuilder recipeBuilder;
+
+    @Mock
+    private RequestsFinishedNotifier requestsFinishedNotifier;
+
+    @Mock
+    private FailureNotifier failureNotifier;
+
+    @Mock
+    private RunManagement runManagement;
+
+    @Captor
+    private ArgumentCaptor<GenerationRecord> generationRecordCaptor;
+
+    // Helper to satisfy Avro's strict requirements for the Context field
+    private ContextSpec createDummyContext() {
+        return ContextSpec.newBuilder()
+            .setEventId("event-123")
+            .setType("TestEvent")
+            .setSource("TestSource")
+            .setCorrelationId("corr-123")
+            .setEventVersion("1.0")
+            .setTimestamp(Instant.now())
+            .build();
+    }
+
+    @Test
+    void testProcessGenerations() {
+        // Setup initial request
+        Target dummyTarget = Target.newBuilder()
+            .setType("purl")
+            .setIdentifier("pkg:maven/test/test@1.0")
+            .build();
+
+        GenerationRequestSpec genSpec = GenerationRequestSpec.newBuilder()
+            .setGenerationId("gen-123") // Required by Avro
+            .setTarget(dummyTarget)     // Required by Avro/Mapper
+            .build();
+
+        RequestData reqData = RequestData.newBuilder()
+            .setRequestId("req-123")
+            .setGenerationRequests(List.of(genSpec))
+            .build();
+
+        RequestsCreated requestsCreated = RequestsCreated.newBuilder()
+            .setContext(createDummyContext()) // Required by Avro
+            .setData(reqData)
+            .build();
+
+        RequestRecord requestRecord = new RequestRecord();
+        GenerationRecord generationRecord = new GenerationRecord();
+        generationRecord.setId("gen-123");
+
+        // Mock mapper behaviors using mock() instead of Avro builders
+        GenerationCreated mockedGenerationCreated = mock(GenerationCreated.class);
+
+        when(sbomMapper.toNewRequestRecord(requestsCreated)).thenReturn(requestRecord);
+        when(sbomMapper.toNewGenerationRecord(eq(genSpec), eq("req-123"))).thenReturn(generationRecord);
+        when(sbomMapper.toGenerationCreatedEvent(eq(generationRecord), eq(genSpec), eq("req-123")))
+            .thenReturn(mockedGenerationCreated);
+
+        // Execute
+        sbomService.processGenerations(requestsCreated);
+
+        // Verify repository saves
+        verify(statusRepository).saveRequestRecord(requestRecord);
+        verify(statusRepository).saveGeneration(generationRecord);
+        verify(statusRepository).saveGenerationRun(any(GenerationRunRecord.class));
+
+        // Verify scheduler and roll-up
+        verify(generationScheduler).schedule(mockedGenerationCreated);
+        verify(runManagement).rollUpGenerationsToRequest("req-123");
+    }
+
+    @Test
+    void testProcessGenerationStatusUpdate_Finished_NoEnhancements() {
+        // Setup data
+        String generationId = "gen-123";
+        String requestId = "req-123";
+        String runId = "run-123";
+
+        GenerationUpdateData updateData = GenerationUpdateData.newBuilder()
+            .setGenerationId(generationId)
+            .setStatus("FINISHED")
+            .setResultCode(0)
+            .setBaseSbomUrls(List.of("http://base-url.com"))
+            .build();
+
+        GenerationUpdate generationUpdate = GenerationUpdate.newBuilder()
+            .setContext(createDummyContext()) // Required by Avro
+            .setData(updateData)
+            .build();
+
+        GenerationRecord record = new GenerationRecord();
+        record.setId(generationId);
+        record.setRequestId(requestId);
+        record.setEnhancements(Collections.emptyList()); // NO Enhancements
+
+        GenerationRunRecord runRecord = new GenerationRunRecord();
+        runRecord.setId(runId);
+        runRecord.setState(RunState.RUNNING);
+
+        RequestRecord requestRecord = new RequestRecord();
+        RequestsFinished mockedRequestsFinished = mock(RequestsFinished.class);
+
+        // Mocks
+        when(statusRepository.findGenerationById(generationId)).thenReturn(record);
+        when(statusRepository.findGenerationRunsByGenerationId(generationId)).thenReturn(List.of(runRecord));
+        when(statusRepository.isGenerationAndEnhancementsFinished(generationId)).thenReturn(true);
+        when(statusRepository.isAllGenerationRequestsFinished(requestId)).thenReturn(true);
+        when(statusRepository.findRequestById(requestId)).thenReturn(requestRecord);
+        when(sbomMapper.toRequestsFinishedEvent(requestRecord)).thenReturn(mockedRequestsFinished);
+
+        // Execute
+        sbomService.processGenerationStatusUpdate(generationUpdate);
+
+        // Verify Run completion
+        verify(runManagement).completeGenerationRun(runId, GenerationResult.SUCCESS, "Generation completed");
+
+        // Verify Generation Update (Capturing the record to check finalSbomUrls)
+        verify(statusRepository, times(2)).updateGeneration(generationRecordCaptor.capture());
+        GenerationRecord updatedRecord = generationRecordCaptor.getAllValues().get(1);
+
+        // Assert base URLs were used as final URLs since there are no enhancements
+        assertThat(updatedRecord.getGenerationSbomUrls()).containsExactly("http://base-url.com");
+        assertThat(updatedRecord.getFinalSbomUrls()).containsExactly("http://base-url.com");
+
+        // Verify Request completion
+        verify(statusRepository).updateRequestRecord(requestRecord);
+        assertThat(requestRecord.getStatus()).isEqualTo(RequestStatus.COMPLETED);
+        verify(requestsFinishedNotifier).notify(mockedRequestsFinished);
+    }
+
+    @Test
+    void testProcessEnhancementStatusUpdate_Finished_CompletesRequest() {
+        // Setup data
+        String enhancementId = "enh-123";
+        String generationId = "gen-123";
+        String requestId = "req-123";
+        String runId = "run-123";
+
+        EnhancementUpdateData updateData = EnhancementUpdateData.newBuilder()
+            .setEnhancementId(enhancementId)
+            .setStatus("FINISHED")
+            .setResultCode(0)
+            .setEnhancedSbomUrls(List.of("http://enhanced-url-2.com"))
+            .build();
+
+        EnhancementUpdate enhancementUpdate = EnhancementUpdate.newBuilder()
+            .setContext(createDummyContext()) // Required by Avro
+            .setData(updateData)
+            .build();
+
+        EnhancementRecord enh1 = new EnhancementRecord();
+        enh1.setIndex(0);
+        enh1.setEnhancedSbomUrls(List.of("http://enhanced-url-1.com"));
+
+        EnhancementRecord enh2 = new EnhancementRecord();
+        enh2.setId(enhancementId);
+        enh2.setGenerationId(generationId);
+        enh2.setRequestId(requestId);
+        enh2.setIndex(1); // Higher index
+        enh2.setEnhancedSbomUrls(List.of("http://enhanced-url-2.com"));
+
+        GenerationRecord genRecord = new GenerationRecord();
+        genRecord.setId(generationId);
+        genRecord.setRequestId(requestId);
+        genRecord.setGenerationSbomUrls(List.of("http://base-url.com"));
+        genRecord.setEnhancements(List.of(enh1, enh2)); // HAS Enhancements
+
+        EnhancementRunRecord runRecord = new EnhancementRunRecord();
+        runRecord.setId(runId);
+        runRecord.setState(RunState.RUNNING);
+
+        RequestRecord requestRecord = new RequestRecord();
+        RequestsFinished mockedRequestsFinished = mock(RequestsFinished.class);
+
+        // Mocks
+        when(statusRepository.findEnhancementById(enhancementId)).thenReturn(enh2);
+        when(statusRepository.findEnhancementRunsByEnhancementId(enhancementId)).thenReturn(List.of(runRecord));
+        when(statusRepository.findGenerationById(generationId)).thenReturn(genRecord);
+        when(statusRepository.isGenerationAndEnhancementsFinished(generationId)).thenReturn(true);
+        when(statusRepository.isAllGenerationRequestsFinished(requestId)).thenReturn(true);
+        when(statusRepository.findRequestById(requestId)).thenReturn(requestRecord);
+        when(sbomMapper.toRequestsFinishedEvent(requestRecord)).thenReturn(mockedRequestsFinished);
+
+        // Execute
+        sbomService.processEnhancementStatusUpdate(enhancementUpdate);
+
+        // Verify Generation Update (Checking max index logic)
+        verify(statusRepository).updateGeneration(generationRecordCaptor.capture());
+        GenerationRecord updatedGenRecord = generationRecordCaptor.getValue();
+
+        // Assert max-index enhanced URLs were used as final URLs
+        assertThat(updatedGenRecord.getFinalSbomUrls()).containsExactly("http://enhanced-url-2.com");
+
+        // Verify Request completion
+        verify(requestsFinishedNotifier).notify(mockedRequestsFinished);
+    }
 }


### PR DESCRIPTION
In our current data model, while we do store and show URLs for each individual sub-step of the Generation->Enhancement process (i.e. the final enhancement urls), we have to explicitly calculate the final SBOM URLs each time we need to make use of them (for example in the requests.finished event send), while it looks we will more often need to query and show these URLs for example in the request results, where these URLs will be of main interest to the end user. So it makes sense for them to be calculated once and stored in the database just like the others for easier retrieval.

This PR introduces a new finalsbomurls field for a generationrecord and generationentity and gets set once all the generation and enhancements of the individual generation request is finished, and then can be shown by the REST API