### PR TITLE
fix: add validation before creating request entity

### DIFF
--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/kafka/generation/KafkaGenerationProcessor.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/kafka/generation/KafkaGenerationProcessor.java
@@ -1,30 +1,89 @@
 package org.jboss.sbomer.sbom.service.adapter.in.kafka.generation;
 
+import java.util.List;
+
 import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.jboss.sbomer.events.common.GenerationRequestSpec;
 import org.jboss.sbomer.events.request.RequestsCreated;
 import org.jboss.sbomer.sbom.service.core.port.api.generation.GenerationProcessor;
+import org.jboss.sbomer.sbom.service.core.utility.RequestValidator;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Kafka event listener that processes generation requests
+ * Kafka event listener that processes generation requests.
+ * Validates requests before passing to core service layer.
  */
 @ApplicationScoped
 @Slf4j
 public class KafkaGenerationProcessor {
 
     private GenerationProcessor generationProcessor;
+    private RequestValidator requestValidator;
 
     @Inject
-    KafkaGenerationProcessor(GenerationProcessor generationProcessor) {
+    KafkaGenerationProcessor(
+        GenerationProcessor generationProcessor,
+        RequestValidator requestValidator
+    ) {
         this.generationProcessor = generationProcessor;
+        this.requestValidator = requestValidator;
+    }
+
+    @PostConstruct
+    void init() {
+        log.debug("KafkaGenerationProcessor initialized with validation");
     }
 
     @Incoming("requests-created")
     public void processGenerationsFromKafka(RequestsCreated requestsCreated) {
-        log.info("Received requests.created event from" + requestsCreated.getContext().getSource() + ". Setting up and dispatching to generators");
+        String source = requestsCreated.getContext().getSource();
+        String requestId = requestsCreated.getData().getRequestId();
+
+        log.info("Received requests.created event from {} with requestId: {}", source, requestId);
+
+        // Validate before processing
+        List<GenerationRequestSpec> specs = requestsCreated.getData().getGenerationRequests();
+        RequestValidator.ValidationResult validationResult = requestValidator.validate(specs);
+
+        if (!validationResult.isValid()) {
+            logValidationErrors(validationResult, source, requestId);
+            return; // Return without processing (no entities created)
+        }
+
+        // All valid
+        log.info("Validation passed. Setting up and dispatching to generators: requestId={}", requestId);
         generationProcessor.processGenerations(requestsCreated);
+    }
+
+    /**
+     * Logs validation errors for debugging and monitoring.
+     *
+     * @param validationResult The validation result containing errors
+     * @param source The event source
+     * @param requestId The request ID
+     */
+    private void logValidationErrors(
+            RequestValidator.ValidationResult validationResult,
+            String source,
+            String requestId) {
+        log.error("Invalid requests.created event from {}: requestId={}, errors={}",
+            source,
+            requestId,
+            validationResult.getErrors().size());
+
+        // Log each validation error for debugging
+        validationResult.getErrors().forEach(error ->
+            log.error("  - Request[{}]: type={}, identifier={}, reason={}",
+                error.getIndex(),
+                error.getTargetType(),
+                error.getTargetIdentifier(),
+                error.getReason())
+        );
+
+        log.warn("Ignoring invalid requests.created event: requestId={}", requestId);
     }
 }

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/SbomResource.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/in/rest/SbomResource.java
@@ -31,10 +31,12 @@ import org.jboss.sbomer.sbom.service.core.domain.dto.EnhancementRunRecord;
 import org.jboss.sbomer.sbom.service.core.domain.dto.GenerationRecord;
 import org.jboss.sbomer.sbom.service.core.domain.dto.GenerationRunRecord;
 import org.jboss.sbomer.sbom.service.core.domain.dto.RequestRecord;
+import org.jboss.sbomer.sbom.service.core.domain.enums.ErrorResult;
 import org.jboss.sbomer.sbom.service.core.domain.exception.EntityNotFoundException;
 import org.jboss.sbomer.sbom.service.core.domain.exception.ValidationException;
 import org.jboss.sbomer.sbom.service.core.port.api.SbomAdministration;
 import org.jboss.sbomer.sbom.service.core.port.api.generation.GenerationProcessor;
+import org.jboss.sbomer.sbom.service.core.utility.RequestValidator;
 import org.jboss.sbomer.sbom.service.core.utility.TsidUtility;
 
 import jakarta.annotation.PostConstruct;
@@ -73,6 +75,9 @@ public class SbomResource {
     @Inject
     GenerationProcessor generationProcessor;
 
+    @Inject
+    RequestValidator requestValidator;
+
     /**
      * Validates that all required dependencies are properly injected.
      * This method is called after dependency injection is complete but before the bean is put into service.
@@ -81,6 +86,8 @@ public class SbomResource {
     void init() {
         Objects.requireNonNull(sbomAdministration, "SbomAdministration must be injected");
         Objects.requireNonNull(generationProcessor, "GenerationProcessor must be injected");
+        Objects.requireNonNull(requestValidator, "RequestValidator must be injected");
+
         log.debug("SbomResource initialized successfully with all dependencies");
     }
 
@@ -337,10 +344,19 @@ public class SbomResource {
         // 1. Translate the REST DTO into the internal Avro event object
         RequestsCreated requestsCreatedEvent = toRequestsCreatedEvent(request);
 
-        // 2. Pass the event to the core business logic (the "Port")
+        // 2. Validate before processing
+        List<GenerationRequestSpec> specs = requestsCreatedEvent.getData().getGenerationRequests();
+        RequestValidator.ValidationResult validationResult = requestValidator.validate(specs);
+
+        Optional<Response> validationResponse = handleValidationResult(validationResult);
+        if (validationResponse.isPresent()) {
+            return validationResponse.get();
+        }
+
+        // 3. Pass the event to the core business logic (the "Port")
         generationProcessor.processGenerations(requestsCreatedEvent);
 
-        // 3. Return a 202 Accepted response, as this is an async process.
+        // 4. Return a 202 Accepted response, as this is an async process.
         // We return the batch RequestId so the user can track it.
         String requestId = requestsCreatedEvent.getData().getRequestId();
         log.info("Successfully triggered generation with request ID: {}", requestId);
@@ -447,4 +463,36 @@ public class SbomResource {
                 .setHandlerProvidedOptions(dto.handlerProvidedOptions())
                 .build();
     }
+
+    /**
+     * Handles validation result and returns error response if validation failed.
+     * Uses Optional to avoid null handling and make the optionality explicit.
+     *
+     * @param validationResult The validation result to handle
+     * @return Optional containing error Response if validation failed, empty if valid
+     */
+    private Optional<Response> handleValidationResult(RequestValidator.ValidationResult validationResult) {
+        if (!validationResult.isValid()) {
+            log.warn("Request validation failed: {} errors found", validationResult.getErrors().size());
+
+            ErrorResponse errorResponse = new ErrorResponse(
+                ErrorResult.INVALID_REQUEST,
+                requestValidator.formatValidationErrors(validationResult),
+                Response.Status.BAD_REQUEST.getStatusCode(),
+                ErrorResult.INVALID_REQUEST.getCategory(),
+                null, // correlationId
+                null, // generationId
+                null, // enhancementId
+                Instant.now().toString()
+            );
+
+            return Optional.of(Response.status(Response.Status.BAD_REQUEST)
+                .entity(errorResponse)
+                .build());
+        }
+        
+        return Optional.empty(); // Validation passed
+    }
+
+
 }

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/recipe/ConfigurableRecipeBuilder.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/recipe/ConfigurableRecipeBuilder.java
@@ -2,6 +2,7 @@ package org.jboss.sbomer.sbom.service.adapter.out.recipe;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.sbomer.events.common.EnhancerSpec;
@@ -75,5 +76,25 @@ public class ConfigurableRecipeBuilder implements RecipeBuilder {
         }
 
         return builder.build();
+    }
+
+    @Override
+    public boolean hasRecipeFor(String type) {
+        if (type == null || type.isBlank()) {
+            return false;
+        }
+        
+        try {
+            configProvider.getRecipeForTargetType(type);
+            return true;
+        } catch (IllegalArgumentException e) {
+            log.debug("No recipe found for type: {}", type);
+            return false;
+        }
+    }
+
+    @Override
+    public Set<String> getSupportedTypes() {
+        return configProvider.getAllRecipeTypes();
     }
 }

--- a/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/recipe/ConfigurationProvider.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/adapter/out/recipe/ConfigurationProvider.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.sbomer.sbom.service.adapter.out.recipe.config.RecipeConfig;
@@ -81,6 +83,17 @@ public class ConfigurationProvider {
 
     public RecipeConfig getRecipeForTargetType(String type) {
         return config.getRecipeForType(type);
+    }
+
+    /**
+     * Get all configured recipe types.
+     * 
+     * @return Set of target type names
+     */
+    public Set<String> getAllRecipeTypes() {
+        return config.getRecipes().stream()
+            .map(RecipeConfig::getType)
+            .collect(Collectors.toSet());
     }
 }
 

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/port/spi/RecipeBuilder.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/port/spi/RecipeBuilder.java
@@ -1,5 +1,7 @@
 package org.jboss.sbomer.sbom.service.core.port.spi;
 
+import java.util.Set;
+
 import org.jboss.sbomer.events.orchestration.Recipe;
 
 /**
@@ -11,7 +13,27 @@ public interface RecipeBuilder {
 
     /**
      * Specify an available generator + enhancers for a given type and identifier
+     * 
+     * @param type The target type (e.g., "CONTAINER_IMAGE", "RPM")
+     * @param identifier The target identifier
+     * @return The built recipe
+     * @throws IllegalArgumentException if no recipe exists for the type
      */
     Recipe buildRecipeFor(String type, String identifier);
+
+    /**
+     * Check if a recipe exists for the given target type.
+     * 
+     * @param type The target type to check
+     * @return true if a recipe is configured for this type
+     */
+    boolean hasRecipeFor(String type);
+
+    /**
+     * Get all supported target types.
+     * 
+     * @return Set of supported target type names
+     */
+    Set<String> getSupportedTypes();
 
 }

--- a/src/main/java/org/jboss/sbomer/sbom/service/core/utility/RequestValidator.java
+++ b/src/main/java/org/jboss/sbomer/sbom/service/core/utility/RequestValidator.java
@@ -1,0 +1,115 @@
+package org.jboss.sbomer.sbom.service.core.utility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.sbomer.events.common.GenerationRequestSpec;
+import org.jboss.sbomer.sbom.service.core.port.spi.RecipeBuilder;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Validates generation requests before processing.
+ * Used by both REST and Kafka adapters to ensure only valid requests
+ * are passed to the core service layer.
+ */
+@ApplicationScoped
+public class RequestValidator {
+
+    private final RecipeBuilder recipeBuilder;
+
+    @Inject
+    public RequestValidator(RecipeBuilder recipeBuilder) {
+        this.recipeBuilder = recipeBuilder;
+    }
+
+    /**
+     * Validates a list of generation request specifications.
+     */
+    public ValidationResult validate(List<GenerationRequestSpec> specs) {
+        if (specs == null || specs.isEmpty()) {
+            return new ValidationResult(false, List.of(
+                new ValidationError(-1, null, null, "At least one generation request is required")
+            ));
+        }
+
+        List<ValidationError> errors = new ArrayList<>();
+        for (int i = 0; i < specs.size(); i++) {
+            validateSpec(specs.get(i), i).ifPresent(errors::add);
+        }
+
+        return new ValidationResult(errors.isEmpty(), errors);
+    }
+
+    private java.util.Optional<ValidationError> validateSpec(GenerationRequestSpec spec, int index) {
+        if (spec.getTarget() == null) {
+            return java.util.Optional.of(new ValidationError(index, null, null, "Target cannot be null"));
+        }
+
+        String type = spec.getTarget().getType();
+        String id = spec.getTarget().getIdentifier();
+
+        if (isBlank(type)) {
+            return java.util.Optional.of(new ValidationError(index, type, id, "Target type cannot be null or empty"));
+        }
+        if (isBlank(id)) {
+            return java.util.Optional.of(new ValidationError(index, type, id, "Target identifier cannot be null or empty"));
+        }
+        if (!recipeBuilder.hasRecipeFor(type)) {
+            return java.util.Optional.of(new ValidationError(index, type, id, "Unsupported target type: " + type));
+        }
+
+        return java.util.Optional.empty();
+    }
+
+    private boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    /**
+     * Get all supported target types for error messages.
+     */
+    public Set<String> getSupportedTypes() {
+        return recipeBuilder.getSupportedTypes();
+    }
+
+    /**
+     * Format validation errors into a human-readable message.
+     * 
+     * @param validationResult The validation result containing errors
+     * @return Formatted error message with all validation failures
+     */
+    public String formatValidationErrors(ValidationResult validationResult) {
+        String errorDetails = validationResult.getErrors().stream()
+            .map(error -> String.format("Request[%d]: %s%s",
+                error.getIndex(),
+                error.getReason(),
+                error.getTargetType() != null ? " (type=" + error.getTargetType() + ")" : ""))
+            .collect(java.util.stream.Collectors.joining("; "));
+        
+        return String.format("Request validation failed with %d error(s): %s. Supported types: %s",
+            validationResult.getErrors().size(),
+            errorDetails,
+            getSupportedTypes());
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ValidationResult {
+        private final boolean valid;
+        private final List<ValidationError> errors;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ValidationError {
+        private final int index;
+        private final String targetType;
+        private final String targetIdentifier;
+        private final String reason;
+    }
+}

--- a/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/utility/RequestValidatorTest.java
+++ b/src/test/java/org/jboss/sbomer/test/unit/sbom/service/core/utility/RequestValidatorTest.java
@@ -1,0 +1,236 @@
+package org.jboss.sbomer.test.unit.sbom.service.core.utility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.sbomer.events.common.GenerationRequestSpec;
+import org.jboss.sbomer.events.common.Target;
+import org.jboss.sbomer.sbom.service.core.port.spi.RecipeBuilder;
+import org.jboss.sbomer.sbom.service.core.utility.RequestValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RequestValidatorTest {
+
+    private RecipeBuilder recipeBuilder;
+    private RequestValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        recipeBuilder = mock(RecipeBuilder.class);
+        validator = new RequestValidator(recipeBuilder);
+    }
+
+    @Test
+    void testValidate_ValidRequests_ReturnsValid() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("CONTAINER_IMAGE", "quay.io/test:v1")
+        );
+        when(recipeBuilder.hasRecipeFor("CONTAINER_IMAGE")).thenReturn(true);
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.getErrors()).isEmpty();
+    }
+
+    @Test
+    void testValidate_InvalidType_ReturnsInvalid() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("NONEXISTENT", "test")
+        );
+        when(recipeBuilder.hasRecipeFor("NONEXISTENT")).thenReturn(false);
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getTargetType()).isEqualTo("NONEXISTENT");
+        assertThat(result.getErrors().get(0).getReason()).contains("Unsupported target type");
+    }
+
+
+
+    @Test
+    void testValidate_EmptyTargetType_ReturnsInvalid() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("", "test")
+        );
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getReason()).contains("Target type cannot be null or empty");
+    }
+
+
+
+    @Test
+    void testValidate_EmptyTargetIdentifier_ReturnsInvalid() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("CONTAINER_IMAGE", "")
+        );
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getReason()).contains("Target identifier cannot be null or empty");
+    }
+
+    @Test
+    void testValidate_EmptyList_ReturnsInvalid() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of();
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getReason()).contains("At least one generation request is required");
+    }
+
+    @Test
+    void testValidate_NullList_ReturnsInvalid() {
+        // Given
+        List<GenerationRequestSpec> specs = null;
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getReason()).contains("At least one generation request is required");
+    }
+
+    @Test
+    void testValidate_MixedValidInvalid_ReturnsInvalid() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("CONTAINER_IMAGE", "quay.io/test:v1"),
+            createValidSpec("NONEXISTENT", "test"),
+            createValidSpec("RPM", "test-rpm")
+        );
+        when(recipeBuilder.hasRecipeFor("CONTAINER_IMAGE")).thenReturn(true);
+        when(recipeBuilder.hasRecipeFor("NONEXISTENT")).thenReturn(false);
+        when(recipeBuilder.hasRecipeFor("RPM")).thenReturn(true);
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().get(0).getIndex()).isEqualTo(1);
+        assertThat(result.getErrors().get(0).getTargetType()).isEqualTo("NONEXISTENT");
+    }
+
+    @Test
+    void testValidate_MultipleInvalid_ReturnsAllErrors() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("INVALID1", "test1"),
+            createValidSpec("INVALID2", "test2")
+        );
+        when(recipeBuilder.hasRecipeFor("INVALID1")).thenReturn(false);
+        when(recipeBuilder.hasRecipeFor("INVALID2")).thenReturn(false);
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+
+        // Then
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).hasSize(2);
+        assertThat(result.getErrors().get(0).getIndex()).isEqualTo(0);
+        assertThat(result.getErrors().get(1).getIndex()).isEqualTo(1);
+    }
+
+    @Test
+    void testGetSupportedTypes_ReturnsSupportedTypes() {
+        // Given
+        Set<String> supportedTypes = Set.of("CONTAINER_IMAGE", "RPM", "MAVEN");
+        when(recipeBuilder.getSupportedTypes()).thenReturn(supportedTypes);
+
+        // When
+        Set<String> result = validator.getSupportedTypes();
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("CONTAINER_IMAGE", "RPM", "MAVEN");
+    }
+
+    @Test
+    void testFormatValidationErrors_SingleError() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("INVALID_TYPE", "test")
+        );
+        when(recipeBuilder.hasRecipeFor("INVALID_TYPE")).thenReturn(false);
+        when(recipeBuilder.getSupportedTypes()).thenReturn(Set.of("CONTAINER_IMAGE", "RPM"));
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+        String formatted = validator.formatValidationErrors(result);
+
+        // Then
+        assertThat(formatted).contains("Request validation failed with 1 error(s)");
+        assertThat(formatted).contains("Request[0]: Unsupported target type: INVALID_TYPE");
+        assertThat(formatted).contains("type=INVALID_TYPE");
+        assertThat(formatted).contains("Supported types: [");
+        assertThat(formatted).contains("CONTAINER_IMAGE");
+        assertThat(formatted).contains("RPM");
+    }
+
+    @Test
+    void testFormatValidationErrors_MultipleErrors() {
+        // Given
+        List<GenerationRequestSpec> specs = List.of(
+            createValidSpec("INVALID1", "test1"),
+            createValidSpec("INVALID2", "test2")
+        );
+        when(recipeBuilder.hasRecipeFor("INVALID1")).thenReturn(false);
+        when(recipeBuilder.hasRecipeFor("INVALID2")).thenReturn(false);
+        when(recipeBuilder.getSupportedTypes()).thenReturn(Set.of("CONTAINER_IMAGE"));
+
+        // When
+        RequestValidator.ValidationResult result = validator.validate(specs);
+        String formatted = validator.formatValidationErrors(result);
+
+        // Then
+        assertThat(formatted).contains("Request validation failed with 2 error(s)");
+        assertThat(formatted).contains("Request[0]");
+        assertThat(formatted).contains("Request[1]");
+        assertThat(formatted).contains("; "); // Separator between errors
+    }
+
+    private GenerationRequestSpec createValidSpec(String type, String identifier) {
+        Target target = Target.newBuilder()
+            .setType(type)
+            .setIdentifier(identifier)
+            .build();
+        
+        return GenerationRequestSpec.newBuilder()
+            .setGenerationId("test-id")
+            .setTarget(target)
+            .build();
+    }
+}


### PR DESCRIPTION
For invalid requests, entity is no longer created, for both kafka and REST inputs.
Before this, invalid request would still create entity in the database.